### PR TITLE
feat(146409):-corrige roteamento de arquivos estáticos, swagger

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import path, include
 from django.http import JsonResponse
-from drf_spectacular.views import SpectacularAPIView
-from usuarios.views import SwaggerFromFileView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 
 def healthcheck(_request):
@@ -15,7 +14,7 @@ _core_urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include('usuarios.urls')),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
-    path('api/docs/', SwaggerFromFileView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('', healthcheck, name='healthcheck'),
 ]
 

--- a/usuarios/views/__init__.py
+++ b/usuarios/views/__init__.py
@@ -1,4 +1,3 @@
-from .swagger import SwaggerFromFileView
 from .usuarios import (
     CriarUsuarioView,
     LoginView,

--- a/usuarios/views/swagger.py
+++ b/usuarios/views/swagger.py
@@ -1,9 +1,0 @@
-from django.conf import settings
-from drf_spectacular.views import SpectacularSwaggerView
-
-
-class SwaggerFromFileView(SpectacularSwaggerView):
-    def _get_schema_url(self, request):
-        url = super()._get_schema_url(request)
-        url_com_prefixo = f'{settings.MS_PATH}{url}' if settings.DJANGO_ENVIRONMENT != 'local' else url
-        return url_com_prefixo


### PR DESCRIPTION
Este pull request corrige o carregamento de arquivos estáticos (CSS/JS) no Django Admin e o fluxo da documentação do Swagger para os ambientes de QA e Homologação.

O que foi feito:

Rotas e Estáticos: Isoladas as rotas da API (usando MS_PATH) das rotas de arquivos estáticos e media (agora na raiz /django_static/).
Swagger: Removida a view customizada (SwaggerFromFileView) e retomado o uso do padrão do drf-spectacular.
Segurança: Atualizado o ALLOWED_HOSTS e adicionado CSRF_TRUSTED_ORIGINS com os domínios oficiais de QA e Homolog (qa-api-sigla e hom-api-sigla).

[AB#146409](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/146409)
[AB#145880](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/145880)