### PR TITLE
feat(147597): Atualiza dados do usuário no login e ajusta link de reset de senha

### DIFF
--- a/usuarios/services/autenticacao.py
+++ b/usuarios/services/autenticacao.py
@@ -69,3 +69,44 @@ class AutenticacaoService:
         resposta['token'] = tokens['access']
         return resposta
 
+    @classmethod
+    def atualizar_usuario_com_dados_autenticacao(cls, *, user: User, dados: Any) -> User:
+        """
+        Atualiza campos do User (nome/email) com base nos dados retornados pelo serviço de autenticação.
+
+        - nome: mapeia para first_name/last_name (split por espaço)
+        - email: mapeia para user.email
+
+        A função é tolerante a variações de chave (Nome/nome, Email/email).
+        """
+        if not isinstance(dados, dict):
+            return user
+
+        nome = dados.get("nome")
+        email = dados.get("email")
+
+        update_fields = []
+
+        if isinstance(nome, str):
+            nome = nome.strip()
+            if nome:
+                parts = [p for p in nome.split(" ") if p]
+                first_name = parts[0] if parts else ""
+                last_name = " ".join(parts[1:]) if len(parts) > 1 else ""
+
+                if first_name and user.first_name != first_name:
+                    user.first_name = first_name
+                    update_fields.append("first_name")
+                if user.last_name != last_name:
+                    user.last_name = last_name
+                    update_fields.append("last_name")
+
+        if isinstance(email, str):
+            email = email.strip()
+            if email and user.email != email:
+                user.email = email
+                update_fields.append("email")
+
+        if update_fields:
+            user.save(update_fields=update_fields)
+        return user

--- a/usuarios/services/email.py
+++ b/usuarios/services/email.py
@@ -43,7 +43,7 @@ class EmailService:
         logger.info("Gerando token de reset para usuário: %s", user.username)
         token_data = TokenService.gerar_token_para_reset(user, email)
 
-        link_reset = f"{settings.APLICACAO_URL}/criar-nova-senha/{token_data['uid']}/{token_data['token']}"
+        link_reset = f"{settings.APLICACAO_URL}criar-nova-senha/{token_data['uid']}/{token_data['token']}"
         contexto_email = {
             "nome_usuario": nome,
             "link_reset": link_reset,

--- a/usuarios/views/usuarios.py
+++ b/usuarios/views/usuarios.py
@@ -76,6 +76,8 @@ class LoginView(TokenObtainPairView):
         except (AutenticacaoRespostaInvalidaError, AutenticacaoUpstreamError, AutenticacaoRequisicaoError):
             return Response({'detail': 'Falha no serviço de autenticação'}, status=status.HTTP_400_BAD_REQUEST)
 
+        # Atualiza nome/email do usuário local com dados retornados da autenticação
+        AutenticacaoService.atualizar_usuario_com_dados_autenticacao(user=usuario, dados=data)
         response_data = AutenticacaoService.montar_resposta_login(data, usuario)
         return Response(response_data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
- Login: após autenticar no serviço externo, atualiza automaticamente o usuário local do Django com nome e e-mail retornados pela autenticação.
  - Faz split do nome para preencher first_name e last_name
  - Só persiste no banco quando houver diferença em relação aos valores atuais (evita writes desnecessários)
- Reset de senha: remove a barra (/) excedente no link de reset para evitar URL incorreta/duplicada.

[AB#147957](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147957)