### PR TITLE
feat(148085): adiciona busca de usuário no EOL por RF

### DIFF
--- a/usuarios/serializers/__init__.py
+++ b/usuarios/serializers/__init__.py
@@ -1,6 +1,6 @@
 from .login import LoginSerializer, LoginResponseSerializer, EsqueciSenhaSerializer
 from .password import ChangePasswordSerializer, CriarNovaSenhaSerializer, AlterarSenhaSerializer
-from .user import CreateUserSerializer
+from .user import CreateUserSerializer, BuscarUsuarioEolSerializer
 
 __all__ = [
     'LoginSerializer',
@@ -10,6 +10,7 @@ __all__ = [
     'CriarNovaSenhaSerializer',
     'AlterarSenhaSerializer',
     'CreateUserSerializer',
+    'BuscarUsuarioEolSerializer',
 ]
 
 

--- a/usuarios/serializers/user.py
+++ b/usuarios/serializers/user.py
@@ -1,15 +1,13 @@
 from rest_framework import serializers
 
 
-class CreateUserSerializer(serializers.Serializer):
-    usuario = serializers.CharField()
-    senha = serializers.CharField(write_only=True)
-    email = serializers.EmailField()
-    
-    def validate(self, data):
-        # Converte usuario -> username e senha -> password após validação
-        data['username'] = data.pop('usuario')
-        data['password'] = data.pop('senha')
-        return data
+class BuscarUsuarioEolSerializer(serializers.Serializer):
+    rf = serializers.CharField()
 
+
+class CreateUserSerializer(serializers.Serializer):
+    username = serializers.CharField()
+    nome = serializers.CharField()
+    email = serializers.EmailField()
+    senha = serializers.CharField(write_only=True)
 

--- a/usuarios/serializers/user.py
+++ b/usuarios/serializers/user.py
@@ -9,5 +9,4 @@ class CreateUserSerializer(serializers.Serializer):
     username = serializers.CharField()
     nome = serializers.CharField()
     email = serializers.EmailField()
-    senha = serializers.CharField(write_only=True)
 

--- a/usuarios/tests/test_usuarios_views.py
+++ b/usuarios/tests/test_usuarios_views.py
@@ -217,7 +217,7 @@ def test_criar_usuario_username_conflict(rf):
     User.objects.create_user(username="existente", email="x@x.com", password="123456")
     request = rf.post(
         "/usuarios/criar-usuario/",
-        {"username": "existente", "nome": "Maria Silva", "senha": "123456", "email": "novo@x.com"},
+        {"username": "existente", "nome": "Maria Silva", "email": "novo@x.com"},
         format="json",
     )
     response = CriarUsuarioView.as_view()(request)
@@ -229,7 +229,7 @@ def test_criar_usuario_email_conflict(rf):
     User.objects.create_user(username="u1", email="igual@x.com", password="123456")
     request = rf.post(
         "/usuarios/criar-usuario/",
-        {"username": "novo", "nome": "Maria Silva", "senha": "123456", "email": "igual@x.com"},
+        {"username": "novo", "nome": "Maria Silva", "email": "igual@x.com"},
         format="json",
     )
     response = CriarUsuarioView.as_view()(request)
@@ -240,7 +240,7 @@ def test_criar_usuario_email_conflict(rf):
 def test_criar_usuario_success(rf):
     request = rf.post(
         "/usuarios/criar-usuario/",
-        {"username": "novo", "nome": "Maria Silva", "senha": "123456", "email": "novo@x.com"},
+        {"username": "novo", "nome": "Maria Silva", "email": "novo@x.com"},
         format="json",
     )
     response = CriarUsuarioView.as_view()(request)
@@ -249,4 +249,5 @@ def test_criar_usuario_success(rf):
     user = User.objects.get(username="novo")
     assert user.first_name == "Maria"
     assert user.last_name == "Silva"
+    assert user.has_usable_password() is False
 

--- a/usuarios/tests/test_usuarios_views.py
+++ b/usuarios/tests/test_usuarios_views.py
@@ -217,7 +217,7 @@ def test_criar_usuario_username_conflict(rf):
     User.objects.create_user(username="existente", email="x@x.com", password="123456")
     request = rf.post(
         "/usuarios/criar-usuario/",
-        {"usuario": "existente", "senha": "123456", "email": "novo@x.com"},
+        {"username": "existente", "nome": "Maria Silva", "senha": "123456", "email": "novo@x.com"},
         format="json",
     )
     response = CriarUsuarioView.as_view()(request)
@@ -229,7 +229,7 @@ def test_criar_usuario_email_conflict(rf):
     User.objects.create_user(username="u1", email="igual@x.com", password="123456")
     request = rf.post(
         "/usuarios/criar-usuario/",
-        {"usuario": "novo", "senha": "123456", "email": "igual@x.com"},
+        {"username": "novo", "nome": "Maria Silva", "senha": "123456", "email": "igual@x.com"},
         format="json",
     )
     response = CriarUsuarioView.as_view()(request)
@@ -240,11 +240,13 @@ def test_criar_usuario_email_conflict(rf):
 def test_criar_usuario_success(rf):
     request = rf.post(
         "/usuarios/criar-usuario/",
-        {"usuario": "novo", "senha": "123456", "email": "novo@x.com"},
+        {"username": "novo", "nome": "Maria Silva", "senha": "123456", "email": "novo@x.com"},
         format="json",
     )
     response = CriarUsuarioView.as_view()(request)
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["user"] == "novo"
-    assert User.objects.filter(username="novo").exists()
+    user = User.objects.get(username="novo")
+    assert user.first_name == "Maria"
+    assert user.last_name == "Silva"
 

--- a/usuarios/urls.py
+++ b/usuarios/urls.py
@@ -7,6 +7,7 @@ from usuarios.views import (
     CriarUsuarioView,
     MeusDadosView,
     AlterarSenhaView,
+    BuscarUsuarioEolView,
 )
 
 from usuarios.views.permissoes import (
@@ -22,6 +23,7 @@ urlpatterns = [
     path('esqueci-minha-senha/', EsqueciSenhaView.as_view(), name='usuario-esqueci-minha-senha'),
     path('criar-nova-senha/', CriarNovaSenhaView.as_view(), name='usuario-criar-nova-senha'),
     path('criar-usuario/', CriarUsuarioView.as_view(), name='usuario-criar'),
+    path('buscar-usuario-eol/', BuscarUsuarioEolView.as_view(), name='buscar-usuario-eol'),
     path('meus-dados/', MeusDadosView.as_view(), name='meus-dados'),
     path('alterar-senha/', AlterarSenhaView.as_view(), name='alterar-senha'),
 

--- a/usuarios/views/__init__.py
+++ b/usuarios/views/__init__.py
@@ -5,6 +5,7 @@ from .usuarios import (
     CriarNovaSenhaView,
     MeusDadosView,
     AlterarSenhaView,
+    BuscarUsuarioEolView,
 )
 from .permissoes import (
     PermissoesDisponiveisView,

--- a/usuarios/views/usuarios.py
+++ b/usuarios/views/usuarios.py
@@ -254,7 +254,7 @@ class CriarUsuarioView(APIView):
             400: OpenApiResponse(description="Dados inválidos"),
             409: OpenApiResponse(description="Usuário já cadastrado"),
         },
-        description="Cria um novo usuário a partir de username, nome, email e senha."
+        description="Cria um novo usuário a partir de username, nome e email."
     )
     def post(self, request):
         serializer = CreateUserSerializer(data=request.data)
@@ -262,7 +262,6 @@ class CriarUsuarioView(APIView):
 
         username = serializer.validated_data['username']
         email = serializer.validated_data['email']
-        senha = serializer.validated_data['senha']
         nome = serializer.validated_data['nome']
 
         if User.objects.filter(username=username).exists():
@@ -283,7 +282,6 @@ class CriarUsuarioView(APIView):
 
         user = User.objects.create_user(
             username=username,
-            password=senha,
             email=email,
             first_name=first_name,
             last_name=last_name,

--- a/usuarios/views/usuarios.py
+++ b/usuarios/views/usuarios.py
@@ -228,7 +228,7 @@ class BuscarUsuarioEolView(APIView):
             logger.exception("Falha ao consultar EOL para RF: %s", rf)
             return Response(
                 {'detail': 'Falha ao consultar o EOL.'},
-                status=status.HTTP_402_BAD_GATEWAY,
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         nome = (info or {}).get('Nome') or (info or {}).get('nome', '')

--- a/usuarios/views/usuarios.py
+++ b/usuarios/views/usuarios.py
@@ -17,13 +17,13 @@ from django.contrib.auth.models import User, Permission, Group
 from django.contrib.contenttypes.models import ContentType
 
 from usuarios.serializers import (
-
     LoginSerializer,
     LoginResponseSerializer,
     EsqueciSenhaSerializer,
     CriarNovaSenhaSerializer,
     AlterarSenhaSerializer,
     CreateUserSerializer,
+    BuscarUsuarioEolSerializer,
 )
 from usuarios.services.autenticacao import AutenticacaoService
 from usuarios.services.sme_integracao import SmeIntegracaoService
@@ -191,6 +191,58 @@ class AlterarSenhaView(APIView):
         return Response({'detail': 'Senha alterada com sucesso'}, status=status.HTTP_200_OK)
 
 
+class BuscarUsuarioEolView(APIView):
+    permission_classes = [permissions.AllowAny]
+    authentication_classes = []
+
+    @extend_schema(
+        request=BuscarUsuarioEolSerializer,
+        responses={
+            200: OpenApiResponse(description="Dados do usuário no EOL"),
+            400: OpenApiResponse(description="Usuário já cadastrado no SIGLA"),
+            404: OpenApiResponse(description="Usuário não encontrado no EOL"),
+            502: OpenApiResponse(description="Falha ao consultar o EOL"),
+        },
+        description="Busca dados do usuário no EOL via RF. Retorna 400 se já existir no SIGLA."
+    )
+    def post(self, request):
+        serializer = BuscarUsuarioEolSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        rf = serializer.validated_data['rf']
+
+        if User.objects.filter(username=rf).exists():
+            return Response(
+                {'detail': 'Usuário já cadastrado no SIGLA.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            info = SmeIntegracaoService.informacao_usuario(rf)
+        except SmeIntegracaoException:
+            return Response(
+                {'detail': 'Usuário não encontrado no EOL.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except Exception:
+            logger.exception("Falha ao consultar EOL para RF: %s", rf)
+            return Response(
+                {'detail': 'Falha ao consultar o EOL.'},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        nome = (info or {}).get('Nome') or (info or {}).get('nome', '')
+        email = (info or {}).get('Email') or (info or {}).get('email', '')
+
+        if not nome and not email:
+            return Response(
+                {'detail': 'Usuário não encontrado no EOL.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        return Response({'username': rf, 'nome': nome, 'email': email}, status=status.HTTP_200_OK)
+
+
 class CriarUsuarioView(APIView):
     permission_classes = [permissions.AllowAny]
     authentication_classes = []
@@ -198,37 +250,47 @@ class CriarUsuarioView(APIView):
     @extend_schema(
         request=CreateUserSerializer,
         responses={
-            201: OpenApiResponse(
-                description="Usuário criado com sucesso"
-            ),
+            201: OpenApiResponse(description="Usuário criado com sucesso"),
             400: OpenApiResponse(description="Dados inválidos"),
             409: OpenApiResponse(description="Usuário já cadastrado"),
         },
-        description="Cria um novo usuário, verificando se o nome de usuário ou e-mail já estão em uso."
+        description="Cria um novo usuário a partir de username, nome, email e senha."
     )
     def post(self, request):
         serializer = CreateUserSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        username = serializer.validated_data.get("username")
-        email = serializer.validated_data.get("email")
+        username = serializer.validated_data['username']
+        email = serializer.validated_data['email']
+        senha = serializer.validated_data['senha']
+        nome = serializer.validated_data['nome']
 
         if User.objects.filter(username=username).exists():
             return Response(
-                {"detail": "Nome de usuário já está cadastrado."},
+                {'detail': 'Nome de usuário já está cadastrado.'},
                 status=status.HTTP_409_CONFLICT,
             )
 
-        if email and User.objects.filter(email=email).exists():
+        if User.objects.filter(email__iexact=email).exists():
             return Response(
-                {"detail": "E-mail já está cadastrado."},
+                {'detail': 'E-mail já está cadastrado.'},
                 status=status.HTTP_409_CONFLICT,
             )
 
-        user = User.objects.create_user(**serializer.validated_data)
+        partes = nome.strip().split(' ', 1)
+        first_name = partes[0]
+        last_name = partes[1] if len(partes) > 1 else ''
+
+        user = User.objects.create_user(
+            username=username,
+            password=senha,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+        )
 
         return Response(
-            {"detail": "Usuário criado com sucesso", "user": user.username},
+            {'detail': 'Usuário criado com sucesso', 'user': user.username},
             status=status.HTTP_201_CREATED,
         )
 

--- a/usuarios/views/usuarios.py
+++ b/usuarios/views/usuarios.py
@@ -200,8 +200,7 @@ class BuscarUsuarioEolView(APIView):
         responses={
             200: OpenApiResponse(description="Dados do usuário no EOL"),
             400: OpenApiResponse(description="Usuário já cadastrado no SIGLA"),
-            404: OpenApiResponse(description="Usuário não encontrado no EOL"),
-            502: OpenApiResponse(description="Falha ao consultar o EOL"),
+            404: OpenApiResponse(description="Usuário não encontrado no EOL")
         },
         description="Busca dados do usuário no EOL via RF. Retorna 400 se já existir no SIGLA."
     )

--- a/usuarios/views/usuarios.py
+++ b/usuarios/views/usuarios.py
@@ -228,7 +228,7 @@ class BuscarUsuarioEolView(APIView):
             logger.exception("Falha ao consultar EOL para RF: %s", rf)
             return Response(
                 {'detail': 'Falha ao consultar o EOL.'},
-                status=status.HTTP_502_BAD_GATEWAY,
+                status=status.HTTP_402_BAD_GATEWAY,
             )
 
         nome = (info or {}).get('Nome') or (info or {}).get('nome', '')


### PR DESCRIPTION
Adiciona o endpoint de busca por RF, valida se o usuário já existe no SIGLA, trata erro de não encontrado e falha de integração, e devolve os dados necessários para o fluxo de cadastro.
Atualiza o payload de criação de usuário, passa a separar nome em first_name e last_name, reforça as validações de conflito por username e e-mail e inclui cobertura de testes.

[AB#148085](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148085) 
[AB#148086](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148086)
[AB#147826](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147826)