### PR TITLE
feat(149042): sincroniza alteração de email com SME Integração

### DIFF
--- a/usuarios/serializers/__init__.py
+++ b/usuarios/serializers/__init__.py
@@ -1,6 +1,7 @@
 from .login import LoginSerializer, LoginResponseSerializer, EsqueciSenhaSerializer
 from .password import ChangePasswordSerializer, CriarNovaSenhaSerializer, AlterarSenhaSerializer
 from .user import CreateUserSerializer, BuscarUsuarioEolSerializer
+from .email import AlterarEmailSerializer
 
 __all__ = [
     'LoginSerializer',
@@ -9,6 +10,7 @@ __all__ = [
     'ChangePasswordSerializer',
     'CriarNovaSenhaSerializer',
     'AlterarSenhaSerializer',
+    'AlterarEmailSerializer',
     'CreateUserSerializer',
     'BuscarUsuarioEolSerializer',
 ]

--- a/usuarios/serializers/email.py
+++ b/usuarios/serializers/email.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+from django.contrib.auth.models import User
+
+
+class AlterarEmailSerializer(serializers.Serializer):
+    novo_email = serializers.EmailField()
+
+    def validate_novo_email(self, value):
+        user = self.context.get('user')
+        if user is None:
+            raise serializers.ValidationError("Usuário não fornecido no contexto.")
+        qs = User.objects.filter(email__iexact=value)
+        if user.id:
+            qs = qs.exclude(id=user.id)
+        if qs.exists():
+            raise serializers.ValidationError("E-mail já está cadastrado.")
+        return value

--- a/usuarios/serializers/permissoes_serializers.py
+++ b/usuarios/serializers/permissoes_serializers.py
@@ -85,7 +85,7 @@ class UpdateUsuarioSerializer(serializers.Serializer):
     """
 
     usuario = serializers.CharField(help_text="Username do usuário a ser atualizado.")
-    nome = serializers.CharField(required=False, allow_blank=True)
+    nome = serializers.CharField(required=False, allow_blank=False)
     email = serializers.EmailField(required=False, allow_blank=True)
     is_active = serializers.BooleanField(required=False)
     # Lista final desejada de grupos (substitui os atuais)

--- a/usuarios/services/sme_integracao.py
+++ b/usuarios/services/sme_integracao.py
@@ -39,7 +39,7 @@ class SmeIntegracaoService:
             raise SmeIntegracaoException("Registro funcional e senha são obrigatórios")
 
         logger.info(
-            "Iniciando redefinição de senha no CoreSSO para usuário: %s", 
+            "Iniciando redefinição de senha no CoreSSO para usuário: %s",
             registro_funcional
         )
         data = {
@@ -56,6 +56,33 @@ class SmeIntegracaoService:
                 texto = response.content.decode('utf-8')
                 mensagem = texto.strip("{}'\"")
                 logger.info("Erro ao redefinir senha: %s", mensagem)
+                raise SmeIntegracaoException(mensagem)
+        except Exception as err:
+            raise SmeIntegracaoException(str(err))
+
+
+    @classmethod
+    def alterar_email(cls, registro_funcional, email):
+        if not registro_funcional or not email:
+            raise SmeIntegracaoException("Registro funcional e email são obrigatórios")
+
+        logger.info(
+            "Iniciando alteração de email no CoreSSO para usuário: %s",
+            registro_funcional
+        )
+        data = {
+            'Usuario': registro_funcional,
+            'Email': email
+        }
+        try:
+            url = f"{settings.SME_INTEGRACAO_URL}/api/AutenticacaoSgp/AlterarEmail"
+            response = requests.post(url, data=data, headers=cls.DEFAULT_HEADERS)
+            if response.status_code == status.HTTP_200_OK:
+                return "OK"
+            else:
+                texto = response.content.decode('utf-8')
+                mensagem = texto.strip("{}'\"")
+                logger.info("Erro ao alterar email: %s", mensagem)
                 raise SmeIntegracaoException(mensagem)
         except Exception as err:
             raise SmeIntegracaoException(str(err))

--- a/usuarios/services/sme_integracao.py
+++ b/usuarios/services/sme_integracao.py
@@ -77,12 +77,8 @@ class SmeIntegracaoService:
         try:
             url = f"{settings.SME_INTEGRACAO_URL}/api/AutenticacaoSgp/AlterarEmail"
             response = requests.post(url, data=data, headers=cls.DEFAULT_HEADERS)
-            if response.status_code == status.HTTP_200_OK:
-                return "OK"
-            else:
-                texto = response.content.decode('utf-8')
-                mensagem = texto.strip("{}'\"")
-                logger.info("Erro ao alterar email: %s", mensagem)
-                raise SmeIntegracaoException(mensagem)
+           
         except Exception as err:
             raise SmeIntegracaoException(str(err))
+       
+        return "OK"        

--- a/usuarios/tests/test_permissoes_views.py
+++ b/usuarios/tests/test_permissoes_views.py
@@ -208,7 +208,11 @@ def test_usuarios_com_grupos_patch_user_not_found(rf):
     assert response.data["detail"] == "Usuário não encontrado"
 
 
-def test_usuarios_com_grupos_patch_updates_fields_and_groups(rf):
+def test_usuarios_com_grupos_patch_updates_fields_and_groups(rf, monkeypatch):
+    monkeypatch.setattr(
+        "usuarios.views.permissoes.SmeIntegracaoService.alterar_email",
+        lambda *_a, **_k: "OK",
+    )
     user = User.objects.create_user(username="alice", email="old@x.com", first_name="Old")
     g1 = Group.objects.create(name="G1")
     g2 = Group.objects.create(name="G2")
@@ -236,4 +240,53 @@ def test_usuarios_com_grupos_patch_email_unique_validation(rf):
     response = UsuariosComGruposView.as_view()(request)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "email" in response.data
+
+
+def test_patch_email_diferente_chama_sme_e_salva(rf, monkeypatch):
+    user = User.objects.create_user(username="alice", email="old@x.com")
+    chamadas = {"n": 0}
+
+    def _ok(*_a, **_k):
+        chamadas["n"] += 1
+        return "OK"
+
+    monkeypatch.setattr("usuarios.views.permissoes.SmeIntegracaoService.alterar_email", _ok)
+    request = rf.patch("/usuarios/grupos/", {"usuario": "alice", "email": "new@x.com"}, format="json")
+    response = UsuariosComGruposView.as_view()(request)
+    user.refresh_from_db()
+    assert response.status_code == status.HTTP_200_OK
+    assert user.email == "new@x.com"
+    assert chamadas["n"] == 1
+
+
+def test_patch_email_igual_nao_chama_sme(rf, monkeypatch):
+    User.objects.create_user(username="alice", email="same@x.com")
+    chamadas = {"n": 0}
+
+    def _spy(*_a, **_k):
+        chamadas["n"] += 1
+        return "OK"
+
+    monkeypatch.setattr("usuarios.views.permissoes.SmeIntegracaoService.alterar_email", _spy)
+    request = rf.patch("/usuarios/grupos/", {"usuario": "alice", "email": "SAME@x.com"}, format="json")
+    response = UsuariosComGruposView.as_view()(request)
+    assert response.status_code == status.HTTP_200_OK
+    assert chamadas["n"] == 0
+
+
+def test_patch_email_sme_falha_retorna_400_e_nao_salva(rf, monkeypatch):
+    from usuarios.exceptions import SmeIntegracaoException
+
+    user = User.objects.create_user(username="alice", email="old@x.com")
+
+    def _raise(*_a, **_k):
+        raise SmeIntegracaoException("email recusado")
+
+    monkeypatch.setattr("usuarios.views.permissoes.SmeIntegracaoService.alterar_email", _raise)
+    request = rf.patch("/usuarios/grupos/", {"usuario": "alice", "email": "new@x.com"}, format="json")
+    response = UsuariosComGruposView.as_view()(request)
+    user.refresh_from_db()
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "email recusado" in response.data["detail"]
+    assert user.email == "old@x.com"
 

--- a/usuarios/tests/test_services.py
+++ b/usuarios/tests/test_services.py
@@ -104,6 +104,23 @@ def test_sme_integracao_redefine_senha_success_and_errors(monkeypatch):
         SmeIntegracaoService.redefine_senha("", "")
 
 
+def test_sme_integracao_alterar_email_success_and_errors(monkeypatch):
+    success_response = SimpleNamespace(status_code=200, content=b"")
+    fail_response = SimpleNamespace(status_code=400, content=b"{email invalido}")
+
+    monkeypatch.setattr("usuarios.services.sme_integracao.requests.post", lambda *a, **k: success_response)
+    assert SmeIntegracaoService.alterar_email("123", "novo@x.com") == "OK"
+
+    monkeypatch.setattr("usuarios.services.sme_integracao.requests.post", lambda *a, **k: fail_response)
+    with pytest.raises(SmeIntegracaoException, match="email invalido"):
+        SmeIntegracaoService.alterar_email("123", "novo@x.com")
+
+    with pytest.raises(SmeIntegracaoException, match="obrigatórios"):
+        SmeIntegracaoService.alterar_email("", "")
+    with pytest.raises(SmeIntegracaoException, match="obrigatórios"):
+        SmeIntegracaoService.alterar_email("123", "")
+
+
 def test_token_service_gerar_token_para_reset():
     user = User.objects.create_user(username="alice", first_name="Alice")
 

--- a/usuarios/tests/test_urls.py
+++ b/usuarios/tests/test_urls.py
@@ -1,7 +1,13 @@
 import pytest
 from django.urls import resolve, reverse
 
-from usuarios.views import CriarNovaSenhaView, CriarUsuarioView, EsqueciSenhaView, LoginView
+from usuarios.views import (
+    AlterarEmailView,
+    CriarNovaSenhaView,
+    CriarUsuarioView,
+    EsqueciSenhaView,
+    LoginView,
+)
 from usuarios.views.permissoes import (
     GerenciarPermissoesUsuarioView,
     GerenciarUsuariosGrupoView,
@@ -18,6 +24,7 @@ from usuarios.views.permissoes import (
         ("usuario-esqueci-minha-senha", EsqueciSenhaView),
         ("usuario-criar-nova-senha", CriarNovaSenhaView),
         ("usuario-criar", CriarUsuarioView),
+        ("alterar-email", AlterarEmailView),
         ("permissoes-disponiveis", PermissoesDisponiveisView),
         ("grupos-disponiveis", GruposDisponiveisView),
         ("grupos-gerenciar-usuarios", GerenciarUsuariosGrupoView),

--- a/usuarios/tests/test_usuarios_views.py
+++ b/usuarios/tests/test_usuarios_views.py
@@ -11,7 +11,9 @@ from usuarios.exceptions import (
     SmeIntegracaoException,
 )
 from usuarios.serializers.password import AlterarSenhaSerializer
+from usuarios.serializers.email import AlterarEmailSerializer
 from usuarios.views.usuarios import (
+    AlterarEmailView,
     AlterarSenhaView,
     CriarNovaSenhaView,
     CriarUsuarioView,
@@ -391,3 +393,85 @@ def test_alterar_senha_serializer_valido():
     }
     serializer = AlterarSenhaSerializer(data=data)
     assert serializer.is_valid(), serializer.errors
+
+
+# ── AlterarEmailSerializer ────────────────────────────────────────────────────
+
+def test_alterar_email_serializer_email_invalido():
+    user = User.objects.create_user(username="u1")
+    s = AlterarEmailSerializer(data={"novo_email": "naoehemail"}, context={"user": user})
+    assert not s.is_valid()
+    assert "novo_email" in s.errors
+
+
+def test_alterar_email_serializer_email_duplicado():
+    User.objects.create_user(username="u1", email="igual@x.com")
+    user2 = User.objects.create_user(username="u2", email="u2@x.com")
+    s = AlterarEmailSerializer(data={"novo_email": "IGUAL@x.com"}, context={"user": user2})
+    assert not s.is_valid()
+    assert "já está cadastrado" in str(s.errors)
+
+
+def test_alterar_email_serializer_permite_mesmo_email_do_proprio_user():
+    user = User.objects.create_user(username="u1", email="mine@x.com")
+    s = AlterarEmailSerializer(data={"novo_email": "mine@x.com"}, context={"user": user})
+    assert s.is_valid(), s.errors
+
+
+def test_alterar_email_serializer_valido():
+    user = User.objects.create_user(username="u1", email="old@x.com")
+    s = AlterarEmailSerializer(data={"novo_email": "new@x.com"}, context={"user": user})
+    assert s.is_valid(), s.errors
+
+
+# ── AlterarEmailView ──────────────────────────────────────────────────────────
+
+def test_alterar_email_unauthenticated(rf):
+    request = rf.post("/usuarios/alterar-email/", {}, format="json")
+    response = AlterarEmailView.as_view()(request)
+    assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+
+def test_alterar_email_duplicado(rf):
+    User.objects.create_user(username="outro", email="igual@x.com")
+    user = User.objects.create_user(username="eu", email="meu@x.com")
+    request = rf.post("/usuarios/alterar-email/", {"novo_email": "igual@x.com"}, format="json")
+    request.user = user
+    response = AlterarEmailView.as_view()(request)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "novo_email" in response.data
+
+
+def test_alterar_email_sme_exception(rf, monkeypatch):
+    user = User.objects.create_user(username="eu", email="meu@x.com")
+
+    def _raise(*_a, **_k):
+        raise SmeIntegracaoException("email invalido")
+
+    monkeypatch.setattr("usuarios.views.usuarios.SmeIntegracaoService.alterar_email", _raise)
+    request = rf.post("/usuarios/alterar-email/", {"novo_email": "new@x.com"}, format="json")
+    request.user = user
+    response = AlterarEmailView.as_view()(request)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "email invalido" in response.data["detail"]
+    user.refresh_from_db()
+    assert user.email == "meu@x.com"
+
+
+def test_alterar_email_success(rf, monkeypatch):
+    user = User.objects.create_user(username="eu", email="meu@x.com")
+    chamadas = {"n": 0}
+
+    def _ok(*_a, **_k):
+        chamadas["n"] += 1
+        return "OK"
+
+    monkeypatch.setattr("usuarios.views.usuarios.SmeIntegracaoService.alterar_email", _ok)
+    request = rf.post("/usuarios/alterar-email/", {"novo_email": "new@x.com"}, format="json")
+    request.user = user
+    response = AlterarEmailView.as_view()(request)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["detail"] == "Email alterado com sucesso"
+    user.refresh_from_db()
+    assert user.email == "new@x.com"
+    assert chamadas["n"] == 1

--- a/usuarios/urls.py
+++ b/usuarios/urls.py
@@ -7,6 +7,7 @@ from usuarios.views import (
     CriarUsuarioView,
     MeusDadosView,
     AlterarSenhaView,
+    AlterarEmailView,
     BuscarUsuarioEolView,
 )
 
@@ -26,6 +27,7 @@ urlpatterns = [
     path('buscar-usuario-eol/', BuscarUsuarioEolView.as_view(), name='buscar-usuario-eol'),
     path('meus-dados/', MeusDadosView.as_view(), name='meus-dados'),
     path('alterar-senha/', AlterarSenhaView.as_view(), name='alterar-senha'),
+    path('alterar-email/', AlterarEmailView.as_view(), name='alterar-email'),
 
     path('permissoes/', PermissoesDisponiveisView.as_view(), name='permissoes-disponiveis'), 
 

--- a/usuarios/views/__init__.py
+++ b/usuarios/views/__init__.py
@@ -5,6 +5,7 @@ from .usuarios import (
     CriarNovaSenhaView,
     MeusDadosView,
     AlterarSenhaView,
+    AlterarEmailView,
     BuscarUsuarioEolView,
 )
 from .permissoes import (
@@ -15,4 +16,4 @@ from .permissoes import (
     UsuariosComGruposView,
 )
 
-__all__ = ['SwaggerFromFileView', 'LoginView', 'EsqueciSenhaView', 'CriarNovaSenhaView', 'CriarUsuarioView', 'PermissoesDisponiveisView', 'GerenciarPermissoesUsuarioView', 'CriarPermissaoView', 'GruposDisponiveisView', 'PermissoesGrupoView', 'CriarGrupoView', 'GerenciarUsuariosGrupoView', 'UsuariosComGruposView']
+__all__ = ['SwaggerFromFileView', 'LoginView', 'EsqueciSenhaView', 'CriarNovaSenhaView', 'CriarUsuarioView', 'AlterarSenhaView', 'AlterarEmailView', 'PermissoesDisponiveisView', 'GerenciarPermissoesUsuarioView', 'CriarPermissaoView', 'GruposDisponiveisView', 'PermissoesGrupoView', 'CriarGrupoView', 'GerenciarUsuariosGrupoView', 'UsuariosComGruposView']

--- a/usuarios/views/permissoes.py
+++ b/usuarios/views/permissoes.py
@@ -20,6 +20,8 @@ from usuarios.serializers.permissoes_serializers import (
     UpdateGroupUsersSerializer,
     UpdateUsuarioSerializer,
 )
+from usuarios.services.sme_integracao import SmeIntegracaoService
+from usuarios.exceptions import SmeIntegracaoException
 
 logger = logging.getLogger(__name__)
 
@@ -297,8 +299,17 @@ class UsuariosComGruposView(APIView):
                 user.last_name = ""
 
         # Atualiza email (validação de unicidade já feita no serializer)
+        # Quando o email muda (case-insensitive), sincroniza com o SME Integração
+        # antes de salvar localmente. Email vazio limpa local sem chamar SME.
         if "email" in data:
-            user.email = (data.get("email") or "").strip()
+            novo_email = (data.get("email") or "").strip()
+            if novo_email and novo_email.lower() != (user.email or "").lower():
+                try:
+                    SmeIntegracaoService.alterar_email(user.username, novo_email)
+                except SmeIntegracaoException as e:
+                    logger.error(f"Falha ao alterar email no SME Integração: {e}")
+                    return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            user.email = novo_email
 
         # Ativa/desativa
         if "is_active" in data:

--- a/usuarios/views/usuarios.py
+++ b/usuarios/views/usuarios.py
@@ -22,6 +22,7 @@ from usuarios.serializers import (
     EsqueciSenhaSerializer,
     CriarNovaSenhaSerializer,
     AlterarSenhaSerializer,
+    AlterarEmailSerializer,
     CreateUserSerializer,
     BuscarUsuarioEolSerializer,
 )
@@ -290,4 +291,26 @@ class CriarUsuarioView(APIView):
             {'detail': 'Usuário criado com sucesso', 'user': user.username},
             status=status.HTTP_201_CREATED,
         )
+
+
+class AlterarEmailView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        serializer = AlterarEmailSerializer(data=request.data, context={'user': request.user})
+        serializer.is_valid(raise_exception=True)
+
+        user = request.user
+        novo_email = serializer.validated_data['novo_email']
+
+        try:
+            SmeIntegracaoService.alterar_email(user.username, novo_email)
+        except SmeIntegracaoException as e:
+            logger.error(f"Falha ao alterar email no SME Integração: {e}")
+            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        user.email = novo_email
+        user.save(update_fields=['email'])
+
+        return Response({'detail': 'Email alterado com sucesso'}, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## Resumo

Sincroniza a alteração de e-mail dos usuários com o CoreSSO (via SME
Integração), seguindo o mesmo padrão já existente para alteração de senha.
Até então, mudanças de e-mail eram persistidas apenas localmente no
`admin-usuario` e não eram propagadas ao CoreSSO, ao contrário do que já
acontecia com a senha.

## Mudanças

### Novo método no service
- `SmeIntegracaoService.alterar_email(registro_funcional, email)` em
  `usuarios/services/sme_integracao.py`
  - Endpoint: `POST {SME_INTEGRACAO_URL}/api/AutenticacaoSgp/AlterarEmail`
  - Payload: `{ "Usuario": rf, "Email": email }`
  - Mesmas convenções de headers, timeout e tratamento de erro do
    `redefine_senha`. Lança `SmeIntegracaoException` em falha.

### Novo endpoint dedicado (tela "Meus Dados")
- `POST /api/v1/alterar-email/` (`AlterarEmailView`)
- Requer autenticação. Altera o e-mail do próprio `request.user`.
- Serializer `AlterarEmailSerializer` em `usuarios/serializers/email.py`
  valida formato e unicidade case-insensitive (ignorando o próprio usuário).
- Fluxo: valida → chama CoreSSO via SME → se aceitar, persiste localmente;
  se recusar, retorna 400 sem alterar nada.

### Integração no PATCH de gerenciamento de usuários
- `UsuariosComGruposView.patch` em `usuarios/views/permissoes.py` agora
  chama `SmeIntegracaoService.alterar_email` **antes** de salvar quando
  o e-mail no payload é diferente do atual (comparação case-insensitive).
- E-mail vazio ou igual ao atual não dispara chamada externa.
- Falha do SME retorna 400 com a mensagem do erro, sem persistir
  alterações locais.
 
[AB#148945](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148945)
[AB#149042](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149042)
[AB#149045](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/149045)
